### PR TITLE
Support cubes with multiple measures per observation.

### DIFF
--- a/src/graphql_qb/resolvers.clj
+++ b/src/graphql_qb/resolvers.clj
@@ -30,18 +30,19 @@
 
 (defn resolve-observations [context args field]
   (let [{:keys [uri] :as dataset} (::dataset field)
+        ds-mapping (context/get-dataset-mapping context uri)
         repo (context/get-repository context)
         dimension-filter (::dimensions-filter args)
-        filter-model (queries/get-observation-filter-model dimension-filter)
+        filter-model (queries/get-observation-filter-model ds-mapping dimension-filter)
         selections (context/get-selections context)
         total-matches (if (total-count-required? selections)
                         (get-observation-count repo uri filter-model))]
     (merge
       (select-keys args [::dimensions-filter ::order-by])
-      {::dataset                     dataset
-       ::filter-model                filter-model
-       :total_matches                total-matches
-       :aggregations                 {::dimensions-filter dimension-filter ::filter-model filter-model :ds-uri uri}})))
+      {::dataset      dataset
+       ::filter-model filter-model
+       :total_matches total-matches
+       :aggregations  {::dimensions-filter dimension-filter ::filter-model filter-model :ds-uri uri}})))
 
 (defn resolve-observations-sparql-query [context _args obs-field]
   (let [config (context/get-configuration context)

--- a/src/graphql_qb/schema/mapping/dataset.clj
+++ b/src/graphql_qb/schema/mapping/dataset.clj
@@ -1,5 +1,6 @@
 (ns graphql-qb.schema.mapping.dataset
-  (:require [graphql-qb.util :as util]))
+  (:require [graphql-qb.util :as util]
+            [graphql-qb.vocabulary :refer [qb:measureType]]))
 
 (def uri :uri)
 (def schema :schema)
@@ -51,3 +52,10 @@
 
 (defn aggregation-measures-enum-group [dataset-mapping]
   (:aggregation-measures-enum dataset-mapping))
+
+(defn has-measure-type-dimension?
+  "Whether the given dataset has an explicit qb:measureType dimension"
+  [dataset-mapping]
+  (let [dims (dimensions dataset-mapping)
+        measure-dim (some (fn [dim] (= qb:measureType (:uri dim))) dims)]
+    (some? measure-dim)))

--- a/src/graphql_qb/types.clj
+++ b/src/graphql_qb/types.clj
@@ -230,8 +230,7 @@
     model)
 
   (project-result [_this binding]
-    (when (= uri (get binding :mp))
-      (get binding :mv))))
+    (throw (ex-info "Not supported - measure values are bound differently depending on the existence of a qb:measureDimension within the dataset" {}))))
 
 (defrecord Dataset [uri name dimensions measures])
 

--- a/test/graphql_qb/types_test.clj
+++ b/test/graphql_qb/types_test.clj
@@ -33,20 +33,7 @@
           dim (->Dimension (URI. "http://dim") 1 type)
           value (URI. "http://val1")
           bindings {:dim1 value}]
-      (is (= value (project-result dim bindings)))))
-
-  (testing "Measure matching measure type"
-    (let [uri (URI. "http://measure")
-          measure (->MeasureType uri 1 true)
-          value 4
-          bindings {:mp uri :mv 4}]
-      (is (= value (project-result measure bindings)))))
-
-  (testing "Measure not matching measure type"
-    (let [uri (URI. "http://measure1")
-          measure (->MeasureType uri 1 true)
-          bindings {:mp (URI. "http://measure2") :mv 5}]
-      (is (nil? (project-result measure bindings))))))
+      (is (= value (project-result dim bindings))))))
 
 (deftest apply-filter-test
   (testing "Ref period dimension"
@@ -58,5 +45,5 @@
                   :ends_after ends-after}
           model (apply-filter dim qm/empty-model filter)]
       (is (= ::qm/var (qm/get-path-binding-value model [:dim1 :begin :time])))
-      (is (= ::qm/var (qm/get-path-binding-value model [:dim1 :end :time]) )))))
+      (is (= ::qm/var (qm/get-path-binding-value model [:dim1 :end :time]))))))
 


### PR DESCRIPTION
Issue #34 - Support cubes which do not specify a qb:measureType
dimension and which may specify multiple measures per observation.
Such cubes should specify a value for each measure at each observation
and the generated query adds a binding for each defined measure type.

The observations query is generated differently for cubes which specify
a qb:measureType dimension and those which do not. Similarly, measure
values within each result binding is mapped differently if the
measureType dimension exists.

Remove unused configuration parameter from get-observation-result.

Remove project-result implementation for MeasureType.